### PR TITLE
update Market.trades() to be able to set offset

### DIFF
--- a/coincheck/market.py
+++ b/coincheck/market.py
@@ -21,6 +21,8 @@ class Market(object):
         params = {}
         if(offset>0):
             params = {'offset':offset}
+            if(offset>99):
+                offset=99
         try :
             url in api_urls
             return ast.literal_eval(requests.get(base_url + api_urls.get(url),params=params).text)

--- a/coincheck/market.py
+++ b/coincheck/market.py
@@ -16,25 +16,28 @@ class Market(object):
         pass
 
 
-    def public_api(self,url):
+    def public_api(self,url,offset=0):
         ''' template function of public api'''
+        params = {}
+        if(offset>0):
+            params = {'offset':offset}
         try :
             url in api_urls
-            return ast.literal_eval(requests.get(base_url + api_urls.get(url)).text)
+            return ast.literal_eval(requests.get(base_url + api_urls.get(url),params=params).text)
         except Exception as e:
             print(e)
-    
+
     def ticker(self):
         '''get latest information of coincheck market'''
-        return self.public_api('ticker') 
-    
-    def trades(self):
+        return self.public_api('ticker')
+
+    def trades(self,offset = 0):
         '''get latest deal history of coincheck market'''
-        return self.public_api('trades') 
-    
+        return self.public_api('trades',offset)
+
     def orderbooks(self):
         '''get latest asks/bids information of coincheck market'''
-        return self.public_api('order_books') 
+        return self.public_api('order_books')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
trades(offset_value)でoffsetを使用できるようにしました。しかし、apiで取得できるのは、最大最新100件間なので、offset_valueの最大値は99に制限しました。